### PR TITLE
Unify log output

### DIFF
--- a/src/AzureDevOpsPolicyConfigurator/Logic/PolicyExecuter.cs
+++ b/src/AzureDevOpsPolicyConfigurator/Logic/PolicyExecuter.cs
@@ -44,7 +44,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
             var async = policyClient.CreatePolicyConfigurationAsync(policyConfiguration, projectId);
 
             Log.Debug(this.Serializer.Serialize(async.Result));
-            Log.Info($"Policy has been created. (Branch: {currentPolicy.Branch}, Repository: {repository.Name}, Type: {policy.Type})");
+            Log.Info($"Policy created. (Repository: {repository.Name}, Branch: {currentPolicy.Branch}, Type: {policy.Type})");
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
             var async = policyClient.UpdatePolicyConfigurationAsync(this.GetPolicyConfiguration(types, repository, policy), projectId, serverPolicy.Id);
 
             Log.Debug(this.Serializer.Serialize(async.Result));
-            Log.Info($"Policy updated. (Branch: {currentPolicy.Branch}, Repository: {repository.Name}, Type: {serverPolicy.Type.DisplayName}, Branch: {serverPolicy.GetBranch()})");
+            Log.Info($"Policy updated. (Repository: {repository.Name}, Branch: {currentPolicy.Branch}, Type: {policy.Type})");
         }
 
         /// <summary>
@@ -83,7 +83,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
             var async = policyClient.DeletePolicyConfigurationAsync(projectId, policy.Id);
             async.Wait();
 
-            Log.Warn($"Policy removed. (Repository: {policy.GetRepositoryId()}, Type: {policy.Type.DisplayName}, Branch: {policy.GetBranch()})");
+            Log.Warn($"Policy removed. (Repository: {policy.GetRepositoryId()}, Branch: {policy.GetBranch()}, Type: {policy.Type.DisplayName})");
         }
 
         private PolicyConfiguration GetPolicyConfiguration(IEnumerable<PolicyType> types, GitRepository repository, Policy policy)

--- a/src/AzureDevOpsPolicyConfigurator/Logic/PolicyExecuterBase.cs
+++ b/src/AzureDevOpsPolicyConfigurator/Logic/PolicyExecuterBase.cs
@@ -85,6 +85,8 @@ namespace AzureDevOpsPolicyConfigurator.Logic
                             continue;
                         }
 
+                        Log.Info($"Starting repository: {repository.Name}");
+
                         var relevantPolicies = this.GetPoliciesForRepository(policyDefinition.Policies, project, repository);
                         var serverPolicy = grouppedRepositories.FirstOrDefault(x => x.Key == repository.Id.ToString());
 
@@ -191,7 +193,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
 
                             if (policy.PolicyEquals(serverPolicy))
                             {
-                                Log.Info($"Policy is uptodate. (Branch: {currentPolicy.Branch}, Type: {policy.Type})");
+                                Log.Info($"Policy is up to date. (Repository: {repository.Name}, Branch: {currentPolicy.Branch}, Type: {policy.Type})");
                             }
                             else
                             {
@@ -220,7 +222,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
                 {
                     if (!allowDeletion)
                     {
-                        Log.Info($"Policy would be removed (Repository: {removeable.GetRepositoryId()}, Type: {removeable.Type.DisplayName}, Branch: {removeable.GetBranch()})");
+                        Log.Info($"Existing policy not defined. Skipping removal due to allowDeletion Flag. (Repository: {removeable.GetRepositoryId()}, Branch: {removeable.GetBranch()}, Type: {removeable.Type.DisplayName})");
                         continue;
                     }
 

--- a/src/AzureDevOpsPolicyConfigurator/Logic/WhatIfExecuter.cs
+++ b/src/AzureDevOpsPolicyConfigurator/Logic/WhatIfExecuter.cs
@@ -39,7 +39,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
             BranchPolicies currentPolicy,
             Policy policy)
         {
-            Log.Info($"Policy not found in Azure DevOps, would be created. (Branch: {currentPolicy.Branch}, Repository: {repository.Name}, Type: {policy.Type})");
+            Log.Info($"Policy not found in Azure DevOps, would be created. (Repository: {repository.Name}, Branch: {currentPolicy.Branch}, Type: {policy.Type})");
             Log.Debug($"Settings is: {policy.SettingsWithScope(repository.Id)}");
         }
 
@@ -62,7 +62,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
             Policy policy,
             PolicyConfiguration serverPolicy)
         {
-            Log.Info($"Policy found, would be updated in Azure DevOps. (Branch: {currentPolicy.Branch}, Repository: {repository.Name}, Type: {serverPolicy.Type.DisplayName}, Branch: {serverPolicy.GetBranch()})");
+            Log.Info($"Policy found, would be updated in Azure DevOps. (Repository: {repository.Name}, Branch: {currentPolicy.Branch}, Type: {serverPolicy.Type.DisplayName})");
             Log.Debug($"Settings is: {policy.SettingsWithScope(repository.Id)}");
         }
 
@@ -74,7 +74,7 @@ namespace AzureDevOpsPolicyConfigurator.Logic
         /// <param name="policy">Policy</param>
         protected override void DeletePolicy(PolicyHttpClient policyClient, Guid projectId, PolicyConfiguration policy)
         {
-            Log.Warn($"Policy not in the definition, would be removed from Azure DevOps. (Repository: {policy.GetRepositoryId()}, Type: {policy.Type.DisplayName}, Branch: {policy.GetBranch()})");
+            Log.Warn($"Policy not in the definition, would be removed from Azure DevOps. (Repository: {policy.GetRepositoryId()}, Branch: {policy.GetBranch()}, Type: {policy.Type.DisplayName})");
         }
     }
 }


### PR DESCRIPTION
Unify how actions are logged (always repo, branch, type). Also log start of processing a new repository in case it is not excluded.