### PR TITLE
Error message should say "collectionurl" instead of "connectionurl"

### DIFF
--- a/src/AzureDevOpsPolicyConfigurator.Tests/ArgumentTests.cs
+++ b/src/AzureDevOpsPolicyConfigurator.Tests/ArgumentTests.cs
@@ -31,7 +31,7 @@ namespace AzureDevOpsPolicyConfigurator.Tests
 
             Assert.NotNull(ex);
             Assert.IsType<ArgumentValidationException>(ex);
-            Assert.Equal("Argument \"connectionurl\" is missing!", ex.Message);
+            Assert.Equal("Argument \"collectionurl\" is missing!", ex.Message);
         }
 
         [Fact(DisplayName = "Test without auth")]

--- a/src/AzureDevOpsPolicyConfigurator/Arguments/Commands/CommandBase.cs
+++ b/src/AzureDevOpsPolicyConfigurator/Arguments/Commands/CommandBase.cs
@@ -20,7 +20,7 @@ namespace AzureDevOpsPolicyConfigurator
         {
             if (string.IsNullOrEmpty(settings.CollectionUrl))
             {
-                throw new ArgumentValidationException("Argument \"connectionurl\" is missing!");
+                throw new ArgumentValidationException("Argument \"collectionurl\" is missing!");
             }
 
             if (settings.Auth == null)


### PR DESCRIPTION
When the `--collectionurl` parameter is omitted, the warning message should say `Argument "collectionurl" is missing!`.